### PR TITLE
Add currency awareness as returned value may not always meet expectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 ### Added
 - Ability to constrain the max price of retrieved flights/trips from the API when 
 using `get_cheapest_flights` or `get_cheapest_return_flights` via the `max_price` kwarg.
+- Added `currency` field to the `Flight` object.
+  - Availability API method `get_all_flights` does not support specifying currency (it is always the currency of the
+  departure country), but this was not documented. `Flight` will now allow the user to see what currency has been
+returned.
+- Log a warning when returned currency doesn't match the configured value.
+  - Primarily to warn users using the `get_all_flights` API that the response isn't as configured.
+  - Might also be useful if the `get_cheapest_flights` and `get_cheapest_return_flights` APIs ever stop respecting
+requests for results in specific currencies.
+
+### Fixed
+- Incorrect date format used for logs.
 
 # [v2.1.0] - 2023.03.12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ requests for results in specific currencies.
 ### Fixed
 - Incorrect date format used for logs.
 
+### Changed
+- It is now _optional_ to specify `currency` when creating an instance of the library.
+  - If not specified, the API decides the return currency (normally the currency of the departure country).
+  - If an API, such as the availability / `get_all_flights` API, doesn't support it anyway, this will be ignored,
+except for the purposes of deciding whether a warning should be shown, where the currencies mismatch.
+
 # [v2.1.0] - 2023.03.12
 ### Added
 - Added flight departure time filter keyword arguments to `get_cheapest_flights` and `get_cheapest_return_flights`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ pip install ryanair-py
 To create an instance:
 ```python
 from ryanair import Ryanair
-api = Ryanair("EUR")  # Euro currency, so could also be GBP etc. also
+
+# You can set a currency at the API instance level, so could also be GBP etc. also.
+# Note that this may not *always* be respected by the API, so always check the currency returned matches
+# your expectation. For example, the underlying API for get_all_flights does not support this.
+api = Ryanair("EUR")
 ```
 ### Get the cheapest one-way flights
 Get the cheapest flights from a given origin airport (returns at most 1 flight to each destination).
@@ -24,14 +28,14 @@ from datetime import datetime, timedelta
 from ryanair import Ryanair
 from ryanair.types import Flight
 
-api = Ryanair("EUR")  # Euro currency, so could also be GBP etc. also
+api = Ryanair(currency="EUR")  # Euro currency, so could also be GBP etc. also
 tomorrow = datetime.today().date() + timedelta(days=1)
 
 flights = api.get_cheapest_flights("DUB", tomorrow, tomorrow + timedelta(days=1))
 
 # Returns a list of Flight namedtuples
 flight: Flight = flights[0]
-print(flight)  # Flight(departureTime=datetime.datetime(2023, 3, 12, 17, 0), flightNumber='FR9717', price=31.99, origin='DUB', originFull='Dublin, Ireland', destination='GOA', destinationFull='Genoa, Italy')
+print(flight)  # Flight(departureTime=datetime.datetime(2023, 3, 12, 17, 0), flightNumber='FR9717', price=31.99, currency='EUR' origin='DUB', originFull='Dublin, Ireland', destination='GOA', destinationFull='Genoa, Italy')
 print(flight.price)  # 9.78
 ```
 ### Get the cheapest return trips (outbound and inbound)
@@ -39,12 +43,12 @@ print(flight.price)  # 9.78
 from datetime import datetime, timedelta
 from ryanair import Ryanair
 
-api = Ryanair("EUR")  # Euro currency, so could also be GBP etc. also
+api = Ryanair(currency="EUR")  # Euro currency, so could also be GBP etc. also
 tomorrow = datetime.today().date() + timedelta(days=1)
 tomorrow_1 = tomorrow + timedelta(days=1)
 
 trips = api.get_cheapest_return_flights("DUB", tomorrow, tomorrow, tomorrow_1, tomorrow_1)
-print(trips[0])  # Trip(totalPrice=85.31, outbound=Flight(departureTime=datetime.datetime(2023, 3, 12, 7, 30), flightNumber='FR5437', price=49.84, origin='DUB', originFull='Dublin, Ireland', destination='EMA', destinationFull='East Midlands, United Kingdom'), inbound=Flight(departureTime=datetime.datetime(2023, 3, 13, 7, 45), flightNumber='FR5438', price=35.47, origin='EMA', originFull='East Midlands, United Kingdom', destination='DUB', destinationFull='Dublin, Ireland'))
+print(trips[0])  # Trip(totalPrice=85.31, outbound=Flight(departureTime=datetime.datetime(2023, 3, 12, 7, 30), flightNumber='FR5437', price=49.84, currency='EUR', origin='DUB', originFull='Dublin, Ireland', destination='EMA', destinationFull='East Midlands, United Kingdom'), inbound=Flight(departureTime=datetime.datetime(2023, 3, 13, 7, 45), flightNumber='FR5438', price=35.47, origin='EMA', originFull='East Midlands, United Kingdom', destination='DUB', destinationFull='Dublin, Ireland'))
 ```
 
 ### Get all available flights between two airports
@@ -55,7 +59,9 @@ from datetime import datetime, timedelta
 from ryanair import Ryanair
 from tabulate import tabulate
 
-api = Ryanair("EUR")
+# We don't need to specify a currency if we're only using `get_all_flights`, as this API doesn't support currency 
+# conversion. It will always return dares denominated in the currency of the departure country.  
+api = Ryanair()
 tomorrow = datetime.today().date() + timedelta(days=1)
 
 flights = api.get_all_flights("DUB", tomorrow, "LGW")
@@ -68,22 +74,22 @@ print(tabulate(flights, headers="keys", tablefmt="github"))
 
 This prints the following:
 
-| departureTime       | flightNumber   |   price | origin   | originFull   | destination   | destinationFull   |
-|---------------------|----------------|---------|----------|--------------|---------------|-------------------|
-| 2023-03-12 06:25:00 | FR 114         |   61.99 | DUB      | Dublin       | LGW           | London (Gatwick)  |
-| 2023-03-12 09:20:00 | FR 112         |   88.12 | DUB      | Dublin       | LGW           | London (Gatwick)  |
-| 2023-03-12 11:30:00 | FR 122         |  120.37 | DUB      | Dublin       | LGW           | London (Gatwick)  |
-| ...                 |                |         |          |              |               |                   |
+| departureTime       | flightNumber   |   price | currency | origin   | originFull   | destination   | destinationFull   |
+|---------------------|----------------|---------|----------|----------|--------------|---------------|-------------------|
+| 2023-03-12 06:25:00 | FR 114         |   61.99 | EUR      | DUB      | Dublin       | LGW           | London (Gatwick)  |
+| 2023-03-12 09:20:00 | FR 112         |   88.12 | EUR      | DUB      | Dublin       | LGW           | London (Gatwick)  |
+| 2023-03-12 11:30:00 | FR 122         |  120.37 | EUR      | DUB      | Dublin       | LGW           | London (Gatwick)  |
+| ...                 |                |         | EUR      |          |              |               |                   |
 
 
 and
 
-| departureTime       | flightNumber   |   price | origin   | originFull   | destination   | destinationFull   |
-|---------------------|----------------|---------|----------|--------------|---------------|-------------------|
-| 2023-03-12 06:25:00 | FR 114         |   61.99 | DUB      | Dublin       | LGW           | LON               |
-| 2023-03-12 06:35:00 | FR 202         |   65.09 | DUB      | Dublin       | STN           | LON               |
-| 2023-03-12 07:10:00 | FR 342         |   65.09 | DUB      | Dublin       | LTN           | LON               |
-| 2023-03-12 08:20:00 | FR 206         |  102.09 | DUB      | Dublin       | STN           | LON               |
-| ...                 |                |         |          |              |               |                   |
+| departureTime       | flightNumber   |   price | currency | origin   | originFull   | destination   | destinationFull   |
+|---------------------|----------------|---------|----------|----------|--------------|---------------|-------------------|
+| 2023-03-12 06:25:00 | FR 114         |   61.99 | EUR      | DUB      | Dublin       | LGW           | LON               |
+| 2023-03-12 06:35:00 | FR 202         |   65.09 | EUR      | DUB      | Dublin       | STN           | LON               |
+| 2023-03-12 07:10:00 | FR 342         |   65.09 | EUR      | DUB      | Dublin       | LTN           | LON               |
+| 2023-03-12 08:20:00 | FR 206         |  102.09 | EUR      | DUB      | Dublin       | STN           | LON               |
+| ...                 |                |         |          |          |              |               |                   |
 
 

--- a/ryanair/types.py
+++ b/ryanair/types.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
 
-Flight = namedtuple("Flight", ("departureTime", "flightNumber", "price", "origin", "originFull",
+Flight = namedtuple("Flight", ("departureTime", "flightNumber", "price", "currency", "origin", "originFull",
                                "destination", "destinationFull"))
 Trip = namedtuple("Trip", ("totalPrice", "outbound", "inbound"))


### PR DESCRIPTION
Addressing issue #2 

Availability / `get_all_flights` doesn't respect custom currency, and just returns prices denominated in the currency of the departure country.

This makes settings a return currency optional when creating the library instance, allows the end user to check the returned currency, and logs a warning if there is a currency set at an instance level but a response's currency doesn't match.

This does not _yet_ support converting the currency for the user if they've set a currency when instantiating the library, but I _may_ support this in the future.