### PR TITLE
Handle situation when availibity api is declined

### DIFF
--- a/ryanair/ryanair.py
+++ b/ryanair/ryanair.py
@@ -44,6 +44,7 @@ class Ryanair:
         self.currency = currency
 
         self._num_queries = 0
+        self.session = requests.Session()
 
     @deprecated(version="2.0.0", reason="deprecated in favour of get_cheapest_flights", action="once")
     def get_flights(self, airport, date_from, date_to, destination_country=None):
@@ -205,7 +206,9 @@ class Ryanair:
     def _retryable_query(self, url, params):
         self._num_queries += 1
 
-        return requests.get(url, params=params).json()
+        # Visit main website to get session cookies
+        self.session.get('https://www.ryanair.com/ie/en')
+        return self.session.get(url, params=params).json()
 
     def _parse_cheapest_flight(self, flight):
         currency = flight['price']['currencyCode']


### PR DESCRIPTION
I think when you get the ban from Ryanair from hammering their API you'll receive message
```
{'code': 'SHIELD_BLOCK', 'message': 'Availability declined'}
```

Let's handle that better, so user knows what to do.